### PR TITLE
MCE-1405: Add-Code-Comment-and-Kube-Localhost-Installation-Manifest

### DIFF
--- a/containers/node/lib/public/OutlookToolbarManifest/OutlookToolbar KUBE-LOCALHOST.xml
+++ b/containers/node/lib/public/OutlookToolbarManifest/OutlookToolbar KUBE-LOCALHOST.xml
@@ -1,0 +1,99 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Created: ce44715c-8c4e-446b-879c-ea9ebe0f09c8 -->
+<OfficeApp xmlns="http://schemas.microsoft.com/office/appforoffice/1.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bt="http://schemas.microsoft.com/office/officeappbasictypes/1.0" xmlns:mailappor="http://schemas.microsoft.com/office/mailappversionoverrides/1.0" xsi:type="MailApp">
+	<!-- Begin Basic Settings: Add-in metadata, used for all versions of Office unless override provided. -->
+	<!-- IMPORTANT! Id must be unique for your add-in, if you reuse this manifest ensure that you change this id to a new GUID. -->
+	<Id>a7201f5a-467e-4794-b1b3-f8ef743cfa6c</Id>
+	<!-- Version. Updates from the store only get triggered if there is a version change. -->
+	<Version>1.5.0.1</Version>
+	<ProviderName>Simpleview Localhost</ProviderName>
+	<DefaultLocale>en-US</DefaultLocale>
+	<!-- The display name of your add-in. Used on the store and various places of the Office UI such as the add-ins dialog. -->
+	<DisplayName DefaultValue="Simpleview LH"/>
+	<Description DefaultValue="Simpleview LH"/>
+	<IconUrl DefaultValue="https://outlook.dev.simpleviewinc.com/Images/sv-icon-64.png"/>
+	<HighResolutionIconUrl DefaultValue="https://outlook.dev.simpleviewinc.com/Images/sv-icon-128.png"/>
+	<SupportUrl DefaultValue="https://www.simpleviewinc.com/products/simpleview-cms/"/>
+	<!-- Domains that will be allowed when navigating. For example, if you use ShowTaskpane and then have an href link, navigation will only be allowed if the domain is on this list. -->
+	<AppDomains>
+		<AppDomain>https://crm3-outlook-add-in.kube.simpleview.io/</AppDomain>
+		<AppDomain>https://outlook.dev.simpleviewinc.com</AppDomain>
+	</AppDomains>
+	<!-- End Basic Settings. -->
+	<Hosts>
+		<Host Name="Mailbox"/>
+	</Hosts>
+	<Requirements>
+		<Sets>
+			<Set Name="Mailbox" MinVersion="1.1"/>
+		</Sets>
+	</Requirements>
+	<FormSettings>
+		<Form xsi:type="ItemRead">
+			<DesktopSettings>
+				<SourceLocation DefaultValue="https://crm3-outlook-add-in.kube.simpleview.io/Pages/Index/Index.html"/>
+				<RequestedHeight>250</RequestedHeight>
+			</DesktopSettings>
+		</Form>
+	</FormSettings>
+	<Permissions>ReadWriteMailbox</Permissions>
+	<Rule xsi:type="RuleCollection" Mode="Or">
+		<Rule xsi:type="ItemIs" ItemType="Message" FormType="Read"/>
+	</Rule>
+	<DisableEntityHighlighting>false</DisableEntityHighlighting>
+	<VersionOverrides xmlns="http://schemas.microsoft.com/office/mailappversionoverrides" xsi:type="VersionOverridesV1_0">
+		<VersionOverrides xmlns="http://schemas.microsoft.com/office/mailappversionoverrides/1.1" xsi:type="VersionOverridesV1_1">
+			<Requirements>
+				<bt:Sets DefaultMinVersion="1.13">
+					<bt:Set Name="Mailbox"/>
+				</bt:Sets>
+			</Requirements>
+			<Hosts>
+				<Host xsi:type="MailHost">
+					<DesktopFormFactor>
+						<ExtensionPoint xsi:type="MessageReadCommandSurface">
+							<OfficeTab id="TabDefault">
+								<Group id="msgReadGroup">
+									<Label resid="GroupLabel"/>
+									<Control xsi:type="Button" id="msgReadOpenPaneButton">
+										<Label resid="TaskpaneButton.Label"/>
+										<Supertip>
+											<Title resid="TaskpaneButton.Label"/>
+											<Description resid="TaskpaneButton.Tooltip"/>
+										</Supertip>
+										<Icon>
+											<bt:Image size="16" resid="Icon.16x16"/>
+											<bt:Image size="32" resid="Icon.32x32"/>
+											<bt:Image size="80" resid="Icon.80x80"/>
+										</Icon>
+										<Action xsi:type="ShowTaskpane">
+											<SourceLocation resid="Taskpane.Url"/>
+											<SupportsMultiSelect>true</SupportsMultiSelect>
+										</Action>
+									</Control>
+								</Group>
+							</OfficeTab>
+						</ExtensionPoint>
+					</DesktopFormFactor>
+				</Host>
+			</Hosts>
+			<Resources>
+				<bt:Images>
+					<bt:Image id="Icon.16x16" DefaultValue="https://outlook.dev.simpleviewinc.com/Images/sv-icon-16.png"/>
+					<bt:Image id="Icon.32x32" DefaultValue="https://outlook.dev.simpleviewinc.com/Images/sv-icon-32.png"/>
+					<bt:Image id="Icon.80x80" DefaultValue="https://outlook.dev.simpleviewinc.com/Images/sv-icon-80.png"/>
+				</bt:Images>
+				<bt:Urls>
+					<bt:Url id="Taskpane.Url" DefaultValue="https://crm3-outlook-add-in.kube.simpleview.io/Pages/Index/Index.html"/>
+				</bt:Urls>
+				<bt:ShortStrings>
+					<bt:String id="GroupLabel" DefaultValue="SimpleView LH"/>
+					<bt:String id="TaskpaneButton.Label" DefaultValue="CRM LH"/>
+				</bt:ShortStrings>
+				<bt:LongStrings>
+					<bt:String id="TaskpaneButton.Tooltip" DefaultValue="Localhost Send messages to SimpleView CRM."/>
+				</bt:LongStrings>
+			</Resources>
+		</VersionOverrides>
+	</VersionOverrides>
+</OfficeApp>

--- a/containers/node/lib/server.js
+++ b/containers/node/lib/server.js
@@ -38,6 +38,8 @@ app.get('/status/', (req, res) => {
 *** @apiUrl: Must be valid CRM URL (e.g. https://demo.simpleviewcrm.com)
 *** POST body data should be in `text/xml` format
 *** The request body size (including email attachments) is limited to 20mb
+*** Note: nginx also has a `client_max_body_size` set to 20mb
+***	If the `limit` param on this route is increased over 20mb, a PR will also need to be submitted to sv-kube-proxy to update `client_max_body_size`
 ***/
 app.post('/submit/', bodyParser.raw({ type: 'text/xml', limit: '20mb' }), routeErrorHandler(async (req, res, next) => {
 	const { apiUrl } = req.query;


### PR DESCRIPTION
- Adding code comment to help ensure the route `limit` stays in line with nginx client_max_body_size set in sv-kube-proxy
- Adding an kube-localhost installation manifest to allow devs to install/test the kube app locally

MCE-1405