### PR TITLE
SA-131845: Use ORB v2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@
 version: 2.1
 
 orbs:
-  circleci-config: simpleviewinc/circleci-config@1
+  circleci-config: simpleviewinc/circleci-config@2
 
 common_config: &common_config
   context: default


### PR DESCRIPTION
Ticket: [SA-131845](https://jira.granicus.com/browse/SA-131845)

## Description

Migrating the CI/CI pipeline to use our internal ORB v2 which implements Workload Identity Federation instead of using the less secured SA JSON key to connect to cloud resources.

A `LEGACY_AUTH` variable is set to `true` in CircleCI's project settings during transition to not break current functionality. Once SV Kubernetes is updated, SA JSON key will be flagged as deprecated and removed in ORB v3.
