### PR TITLE
CRM3-2132: Fix defect preventing users from opening successive dialogue windows

### DIFF
--- a/containers/node/lib/public/Pages/Index/Index.js
+++ b/containers/node/lib/public/Pages/Index/Index.js
@@ -1,4 +1,4 @@
-﻿'use strict';
+'use strict';
 /* global Office, GetDataFromLocalStorageAndSetApiUrlGlobal, ApiUrl*/
 const { createNestablePublicClientApplication } = msal;
 window.MatchedData = {};
@@ -528,6 +528,8 @@ let popupWindow = null;
 let openOfficeDialog = null;
 /** If set, run ReloadTaskPane with this value when the Office dialog closes (avoids reloading while dialog is open). */
 let pendingReloadTaskPane = undefined;
+/** If set, run showOutlookPopup after the Office dialog fully closes (avoids 12007: cannot open a second dialog while the first is active). */
+let pendingShowOutlookPopup = null;
 
 /**
  * Returns true when running inside Office (Outlook desktop or web) with the Dialog API available.
@@ -561,6 +563,8 @@ function openPopupViaOfficeDialog(url, title, width, height, onloadCallback) {
 		console.warn('An Office dialog is already open; only one is allowed.');
 		return;
 	}
+
+	pendingShowOutlookPopup = null;
 
 	const dialogUrl = new URL(url, window.location.href).href;
 	const urlWithMode = dialogUrl + (dialogUrl.indexOf('?') >= 0 ? '&' : '?') + 'mode=dialog';
@@ -614,8 +618,10 @@ function openPopupViaOfficeDialog(url, title, width, height, onloadCallback) {
 				// Treat as simple message (e.g. 'close')
 				if (arg.message === 'close') {
 					if (openOfficeDialog) {
+						// Do not set openOfficeDialog = null here. The host still counts this dialog as
+						// active until DialogEventReceived (12006). Clearing early causes displayDialogAsync
+						// to fail with 12007 if the user opens another dialog immediately (e.g. after Skip).
 						openOfficeDialog.close();
-						openOfficeDialog = null;
 					}
 					if (pendingReloadTaskPane !== undefined) {
 						const doReload = pendingReloadTaskPane;
@@ -631,6 +637,13 @@ function openPopupViaOfficeDialog(url, title, width, height, onloadCallback) {
 		openOfficeDialog.addEventHandler(Office.EventType.DialogEventReceived, function (event) {
 			if (event.error === 12006) {
 				openOfficeDialog = null;
+				if (pendingShowOutlookPopup) {
+					const pending = pendingShowOutlookPopup;
+					pendingShowOutlookPopup = null;
+					if (typeof window.showOutlookPopup === 'function') {
+						window.showOutlookPopup(pending.data, pending.width, pending.height);
+					}
+				}
 			}
 		});
 
@@ -675,10 +688,34 @@ function handleDialogMessageFromChild(msg) {
 			window.CloseTheTaskPane();
 		}
 		break;
+	case 'CloseDialogAndTaskPane':
+		// SendEmail CloseAll (non-sync): do not call CloseTheTaskPane synchronously before close() (12007 zombie).
+		// Some hosts never deliver DialogEventReceived (12006) before the task pane must act again, so run CloseTheTaskPane in a microtask after close()+null.
+		if (openOfficeDialog) {
+			try {
+				openOfficeDialog.close();
+			} catch (e) {
+				console.error('Office dialog close failed:', e);
+			}
+			openOfficeDialog = null;
+		}
+		queueMicrotask(function () {
+			if (typeof window.CloseTheTaskPane === 'function') {
+				window.CloseTheTaskPane();
+			}
+		});
+		break;
 	case 'showOutlookPopup':
 		if (typeof window.showOutlookPopup === 'function') {
 			window.showOutlookPopup(args[0], args[1] || 35, args[2] || 30);
 		}
+		break;
+	case 'DeferShowOutlookPopup':
+		pendingShowOutlookPopup = {
+			data: args[0],
+			width: args[1] != null ? args[1] : 35,
+			height: args[2] != null ? args[2] : 30
+		};
 		break;
 	case 'setCategoryToEmail':
 		if (typeof window.setCategoryToEmail === 'function') {

--- a/containers/node/lib/public/Pages/SendEmail/SendEmail.js
+++ b/containers/node/lib/public/Pages/SendEmail/SendEmail.js
@@ -681,19 +681,24 @@ function CloseAll() {
 			OutboundEmails: EmailSyncCompletedDialogObj.NumberOfOutboundEmails,
 			IsCloseTaskPanel: true
 		};
-		callOpenerNoReturn('showOutlookPopup', dataObj, 35, 30);
 		if (isOfficeDialogMode() && typeof Office !== 'undefined' && Office.context && Office.context.ui) {
+			callOpenerNoReturn('DeferShowOutlookPopup', dataObj, 35, 30);
 			Office.context.ui.messageParent('close');
 		} else {
+			callOpenerNoReturn('showOutlookPopup', dataObj, 35, 30);
 			window.close();
 		}
 	} else {
-		// Close task pane before closing the dialog: if 'close' is handled first, the parent may tear
-		// down the dialog before the JSON message for CloseTheTaskPane is processed (message lost).
-		callOpenerNoReturn('CloseTheTaskPane');
 		if (isOfficeDialogMode() && typeof Office !== 'undefined' && Office.context && Office.context.ui) {
-			Office.context.ui.messageParent('close');
+			// Single parent message: close Office dialog first, defer CloseTheTaskPane until 12006 on parent.
+			// Sending CloseTheTaskPane before close() runs closeContainer() and strands the dialog (12007).
+			try {
+				Office.context.ui.messageParent(JSON.stringify({ method: 'CloseDialogAndTaskPane', args: [] }));
+			} catch (e) {
+				console.error('messageParent CloseDialogAndTaskPane failed:', e);
+			}
 		} else {
+			callOpenerNoReturn('CloseTheTaskPane');
 			window.close();
 		}
 	}


### PR DESCRIPTION
**[Bug fix summary]**

What went wrong

1. 12007 (“already has an active dialog”) — Calling `CloseTheTaskPane` before closing the Send Email Office dialog made Outlook tear down the task pane while the dialog was still shutting down, so the host kept a “ghost” dialog while your script thought nothing was open.

2. Skip / Close all (send, not sync) — The child sent `CloseTheTaskPane` then `close`, which made that ordering easy to hit.

3. Deferring only on 12006 — On some hosts, `DialogEventReceived` (12006) didn’t run in time (or at all) after `close()`, so `CloseTheTaskPane` never ran and `openOfficeDialog` stayed set, blocking the next open.

What we changed

- Non-sync “close everything” (SendEmail.js): one message, CloseDialogAndTaskPane, instead of CloseTheTaskPane + 'close'.

- Index.js: handle it by `dialog.close()`, set `openOfficeDialog = null`, then run `CloseTheTaskPane` in a `queueMicrotask` so `close()` runs before `closeContainer()`, without relying on 12006 for that path.
- **Sync completion popup:** still use `DeferShowOutlookPopup` + `close` so `showOutlookPopup` runs only after 12006 (avoids opening a second Office dialog while the first is active).
- `close` handler: still does not null `openOfficeDialog` until 12006 (avoids reopen race 12007 on normal closes).